### PR TITLE
Add exploratory data visualizations

### DIFF
--- a/notebooks/exploration.ipynb
+++ b/notebooks/exploration.ipynb
@@ -153,14 +153,38 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "id": "fb84fc97",
+   "source": [
+    "### Exploratory Data Analysis\n",
+    "\n",
+    "Visualize feature distributions and pairwise relationships to better understand the Iris dataset before training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "id": "c5e2bae8",
+   "source": [
+    "# Pairplot of features colored by species\n",
+    "eda_data = data.copy()\n",
+    "eda_data.columns = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'species']\n",
+    "sns.pairplot(eda_data, hue='species', diag_kind='hist')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5400e0dd",
    "metadata": {},
    "source": [
     "### Data Preprocessing\n",
     "\n",
-    "- Extract features `X` (columns 0–3) and labels `y` (column 4)\n",
+    "- Extract features `X` (columns 0\u20133) and labels `y` (column 4)\n",
     "- Normalize features using Z-score normalization\n",
-    "- Encode labels: setosa → 0, versicolor → 1, virginica → 2\n",
+    "- Encode labels: setosa \u2192 0, versicolor \u2192 1, virginica \u2192 2\n",
     "- Split into train and validation sets (80/20)\n",
     "- One-hot encode `y_train` and `y_val` for softmax classification"
    ]


### PR DESCRIPTION
## Summary
- Add exploratory data analysis section with pairplot visualizations of iris features prior to preprocessing and model training.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6bdcec124833082cc920b663b2a92